### PR TITLE
Refactor utilities into new module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,11 @@
 # AGENTS Instructions
 
 This repository is a simple Telegram bot powered by Pyrogram and OpenAI.
+The main logic now lives in `app.py` and helper functions are in `bot_utils.py`.
 
 * Whenever you modify any Python file, especially `app.py`, run
-  `python -m py_compile app.py` to ensure there are no syntax errors.
+  `python -m py_compile app.py bot_utils.py` to ensure there are no syntax errors.
 * Use four spaces for indentation.
 * Keep commit messages brief but descriptive.
 * In pull request summaries, mention the key code changes and summarize
   the result of running the above command.
-

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# VictorGram
+
+VictorGram is a small Telegram bot that uses [Pyrogram](https://docs.pyrogram.org/) and OpenAI's API.  Messages from users are forwarded to the language model and the reply is sent back to the chat.
+
+## Features
+
+* Private chat only.
+* Supports text and image messages.
+* System prompts can be customised per user by placing a file in the `prompts/` directory with the user id as filename.
+
+## Setup
+
+1. Install the requirements:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Create a `.env` file with the following variables:
+   - `APP_NAME` – Pyrogram session name
+   - `API_ID` and `API_HASH` – values from [my.telegram.org](https://my.telegram.org)
+   - `OPENAI_API_KEY` – key for OpenAI or configure OLLAMA variables
+3. Run the bot:
+   ```bash
+   python app.py
+   ```
+
+The main entry point is `app.py` and helper functions are located in `bot_utils.py`.

--- a/app.py
+++ b/app.py
@@ -1,26 +1,13 @@
 import os
-import json
 import asyncio
 from dotenv import load_dotenv
 from pyrogram import Client, filters
 from pyrogram.types import Message
-from io import BytesIO
-import base64
 from ai_client import AIClient
+from bot_utils import process_waiting_messages
 
 load_dotenv(".env")
 
-SYSTEM_PROMPTS_DIR = "prompts"
-with open("system_prompt.txt", "r", encoding="utf-8") as f:
-    GENERAL_SYSTEM_PROMPT = f.read().strip()
-
-def get_system_prompt(user_id: int) -> str:
-    path = os.path.join(SYSTEM_PROMPTS_DIR, f"{user_id}.txt")
-    if os.path.exists(path):
-        print(f"ℹ️ Using custom system prompt for user {user_id}")
-        with open(path, "r", encoding="utf-8") as f:
-            return f.read().strip()
-    return GENERAL_SYSTEM_PROMPT
 app = Client(
     name=os.getenv("APP_NAME"),
     api_id=int(os.getenv("API_ID")),
@@ -31,137 +18,6 @@ ai_client = AIClient()
 
 waiting_users = {}
 waiting_lock = asyncio.Lock()
-
-async def message_to_content(client: Client, msg: Message):
-    parts = []
-    text = msg.text or msg.caption
-
-    if not text and not msg.photo and not msg.document:
-        return 0
-
-    if text:
-        parts.append({"type": "text", "text": text})
-
-    media = None
-    mime_type = "image/jpeg"
-    if msg.photo:
-        media = await client.download_media(msg, in_memory=True)
-    elif msg.document and msg.document.mime_type and msg.document.mime_type.startswith("image/"):
-        media = await client.download_media(msg, in_memory=True)
-        mime_type = msg.document.mime_type
-
-    if media:
-        encoded = base64.b64encode(media.getvalue()).decode()
-        parts.append({"type": "image_url", "image_url": {"url": f"data:{mime_type};base64,{encoded}"}})
-
-    if not parts:
-        parts.append({"type": "text", "text": "[non-text message]"})
-
-    return parts
-
-
-def keep_last_image_only(messages):
-    last_index = None
-    last_image = None
-    for i, msg in enumerate(messages):
-        for part in msg["content"]:
-            if part.get("type") == "image_url":
-                last_index = i
-                last_image = part
-    if last_index is None:
-        return messages
-    for msg in messages:
-        msg["content"] = [p for p in msg["content"] if p.get("type") != "image_url"]
-    messages[last_index]["content"].append(last_image)
-    return messages
-
-def merge_text_parts(messages):
-    for msg in messages:
-        new_content = []
-        buffer = []
-        for part in msg["content"]:
-            if part.get("type") == "text":
-                buffer.append(part["text"])
-            else:
-                if buffer:
-                    new_content.append({"type": "text", "text": "\n".join(buffer)})
-                    buffer = []
-                new_content.append(part)
-        if buffer:
-            new_content.append({"type": "text", "text": "\n".join(buffer)})
-        msg["content"] = new_content
-    return messages
-
-
-async def build_openai_messages(client: Client, history, new_messages, system_prompt: str):
-    messages = [{"role": "system", "content": [{"type": "text", "text": system_prompt}]}]
-
-    for msg in history:
-        prepared = await message_to_content(client, msg)
-        if prepared != 0:
-            role = "assistant" if msg.outgoing else "user"
-            if messages[-1]["role"] == role:
-                messages[-1]["content"].extend(prepared)
-            else:
-                messages.append({"role": role, "content": prepared})
-
-    if not isinstance(new_messages, list):
-        new_messages = [new_messages]
-
-    combined_new = []
-    for msg in new_messages:
-        prepared = await message_to_content(client, msg)
-        if prepared != 0:
-            combined_new.extend(prepared)
-
-    if combined_new:
-        if messages[-1]["role"] == "user":
-            messages[-1]["content"].extend(combined_new)
-        else:
-            messages.append({"role": "user", "content": combined_new})
-
-    messages = keep_last_image_only(messages)
-    messages = merge_text_parts(messages)
-    return messages
-
-async def process_waiting_messages(client: Client, user_id: int):
-    print(f"🤖 Processing waiting messages for {user_id}")
-    await asyncio.sleep(int(os.getenv("NEXT_MESSAGE_WAIT_TIME", 10)))
-    async with waiting_lock:
-        msgs = waiting_users.pop(user_id, [])
-    if not msgs:
-        return
-    system_prompt = get_system_prompt(user_id)
-    print(f"🤖 Processing {len(msgs)} messages from {user_id}")
-    try:
-        history = []
-        limit = int(os.getenv("HISTORY_LIMIT")) + len(msgs)
-        async for m in client.get_chat_history(user_id, limit=limit):
-            history.append(m)
-
-        history = []
-        limit = int(os.getenv("HISTORY_LIMIT")) + len(msgs)
-        async for m in client.get_chat_history(user_id, limit=limit):
-            history.append(m)
-
-        for m in reversed(msgs):
-            if history and history[0].id == m.id:
-                history = history[1:]
-        limit = int(os.getenv("HISTORY_LIMIT")) - 1
-        prev_msgs = list(reversed(history[:limit]))
-        openai_messages = await build_openai_messages(client, prev_msgs, msgs, system_prompt)
-        print("🤖 Sending message to AI api")
-        print(json.dumps(openai_messages, ensure_ascii=False, indent=4))
-        reply = ai_client.complete(openai_messages)
-        print(f"🤖 Reply to {msgs[-1].from_user.first_name}: {reply}")
-
-        await msgs[-1].reply_text(reply)
-    except ValueError as e:
-        print(f"❌ Error for chat {user_id}: {e}")
-    except KeyError as e:
-        print(f"❌ Error for chat {user_id}: {e}")
-    except Exception as e:
-        print(f"❌ Unexpected error for chat {user_id}: {e}")
 
 
 @app.on_message(filters.private & filters.incoming)
@@ -181,13 +37,17 @@ async def handle_message(client: Client, message: Message):
         print(f"Skipping group/channel: {message.chat.id}")
         return
 
-    print(f"🤖 Got message from {message.from_user.first_name} ({user_id}): {message.text or 'Non-text message'}")
+    print(
+        f"\U0001F916 Got message from {message.from_user.first_name} ({user_id}): {message.text or 'Non-text message'}"
+    )
 
     async with waiting_lock:
         if user_id in waiting_users:
             waiting_users[user_id].append(message)
             return
         waiting_users[user_id] = [message]
-        asyncio.create_task(process_waiting_messages(client, user_id))
+        asyncio.create_task(
+            process_waiting_messages(client, user_id, waiting_users, waiting_lock, ai_client)
+        )
 
 app.run()

--- a/bot_utils.py
+++ b/bot_utils.py
@@ -1,0 +1,148 @@
+import os
+import json
+import asyncio
+import base64
+from pyrogram import Client
+from pyrogram.types import Message
+
+SYSTEM_PROMPTS_DIR = "prompts"
+with open("system_prompt.txt", "r", encoding="utf-8") as f:
+    GENERAL_SYSTEM_PROMPT = f.read().strip()
+
+def get_system_prompt(user_id: int) -> str:
+    path = os.path.join(SYSTEM_PROMPTS_DIR, f"{user_id}.txt")
+    if os.path.exists(path):
+        print(f"\u2139\ufe0f Using custom system prompt for user {user_id}")
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read().strip()
+    return GENERAL_SYSTEM_PROMPT
+
+async def message_to_content(client: Client, msg: Message):
+    parts = []
+    text = msg.text or msg.caption
+
+    if not text and not msg.photo and not msg.document:
+        return 0
+
+    if text:
+        parts.append({"type": "text", "text": text})
+
+    media = None
+    mime_type = "image/jpeg"
+    if msg.photo:
+        media = await client.download_media(msg, in_memory=True)
+    elif msg.document and msg.document.mime_type and msg.document.mime_type.startswith("image/"):
+        media = await client.download_media(msg, in_memory=True)
+        mime_type = msg.document.mime_type
+
+    if media:
+        encoded = base64.b64encode(media.getvalue()).decode()
+        parts.append({"type": "image_url", "image_url": {"url": f"data:{mime_type};base64,{encoded}"}})
+
+    if not parts:
+        parts.append({"type": "text", "text": "[non-text message]"})
+
+    return parts
+
+def keep_last_image_only(messages):
+    last_index = None
+    last_image = None
+    for i, msg in enumerate(messages):
+        for part in msg["content"]:
+            if part.get("type") == "image_url":
+                last_index = i
+                last_image = part
+    if last_index is None:
+        return messages
+    for msg in messages:
+        msg["content"] = [p for p in msg["content"] if p.get("type") != "image_url"]
+    messages[last_index]["content"].append(last_image)
+    return messages
+
+def merge_text_parts(messages):
+    for msg in messages:
+        new_content = []
+        buffer = []
+        for part in msg["content"]:
+            if part.get("type") == "text":
+                buffer.append(part["text"])
+            else:
+                if buffer:
+                    new_content.append({"type": "text", "text": "\n".join(buffer)})
+                    buffer = []
+                new_content.append(part)
+        if buffer:
+            new_content.append({"type": "text", "text": "\n".join(buffer)})
+        msg["content"] = new_content
+    return messages
+
+async def build_openai_messages(client: Client, history, new_messages, system_prompt: str):
+    messages = [{"role": "system", "content": [{"type": "text", "text": system_prompt}]}]
+
+    for msg in history:
+        prepared = await message_to_content(client, msg)
+        if prepared != 0:
+            role = "assistant" if msg.outgoing else "user"
+            if messages[-1]["role"] == role:
+                messages[-1]["content"].extend(prepared)
+            else:
+                messages.append({"role": role, "content": prepared})
+
+    if not isinstance(new_messages, list):
+        new_messages = [new_messages]
+
+    combined_new = []
+    for msg in new_messages:
+        prepared = await message_to_content(client, msg)
+        if prepared != 0:
+            combined_new.extend(prepared)
+
+    if combined_new:
+        if messages[-1]["role"] == "user":
+            messages[-1]["content"].extend(combined_new)
+        else:
+            messages.append({"role": "user", "content": combined_new})
+
+    messages = keep_last_image_only(messages)
+    messages = merge_text_parts(messages)
+    return messages
+
+async def process_waiting_messages(client: Client, user_id: int, waiting_users, waiting_lock, ai_client):
+    print(f"\U0001F916 Processing waiting messages for {user_id}")
+    await asyncio.sleep(int(os.getenv("NEXT_MESSAGE_WAIT_TIME", 10)))
+    async with waiting_lock:
+        msgs = waiting_users.pop(user_id, [])
+    if not msgs:
+        return
+    system_prompt = get_system_prompt(user_id)
+    print(f"\U0001F916 Processing {len(msgs)} messages from {user_id}")
+    try:
+        history = []
+        limit = int(os.getenv("HISTORY_LIMIT")) + len(msgs)
+        async for m in client.get_chat_history(user_id, limit=limit):
+            history.append(m)
+
+        history = []
+        limit = int(os.getenv("HISTORY_LIMIT")) + len(msgs)
+        async for m in client.get_chat_history(user_id, limit=limit):
+            history.append(m)
+
+        for m in reversed(msgs):
+            if history and history[0].id == m.id:
+                history = history[1:]
+        limit = int(os.getenv("HISTORY_LIMIT")) - 1
+        prev_msgs = list(reversed(history[:limit]))
+        openai_messages = await build_openai_messages(client, prev_msgs, msgs, system_prompt)
+        print("\U0001F916 Sending message to AI api")
+        print(json.dumps(openai_messages, ensure_ascii=False, indent=4))
+        reply = ai_client.complete(openai_messages)
+        print(f"\U0001F916 Reply to {msgs[-1].from_user.first_name}: {reply}")
+
+        await msgs[-1].reply_text(reply)
+    except ValueError as e:
+        print(f"\u274C Error for chat {user_id}: {e}")
+    except KeyError as e:
+        print(f"\u274C Error for chat {user_id}: {e}")
+    except Exception as e:
+        print(f"\u274C Unexpected error for chat {user_id}: {e}")
+


### PR DESCRIPTION
## Summary
- move helper functions to `bot_utils.py`
- shorten `app.py` to focus on bot setup
- document new structure in `AGENTS.md`
- add simple project `README.md`

## Testing
- `python -m py_compile app.py bot_utils.py ai_client.py`

------
https://chatgpt.com/codex/tasks/task_e_686add1b93688328b478df4a6883e481