### PR TITLE
Add typing indicator and prompt generator script

### DIFF
--- a/ai_client.py
+++ b/ai_client.py
@@ -5,8 +5,11 @@ from openai import OpenAI
 load_dotenv(".env")
 
 class AIClient:
-    def __init__(self):
-        use_ollama = os.getenv("USE_OLLAMA", "false").lower() in ["1", "true", "yes"]
+    def __init__(self, api_type=None):
+        if api_type is None:
+            use_ollama = os.getenv("USE_OLLAMA", "false").lower() in ["1", "true", "yes"]
+        else:
+            use_ollama = api_type.lower() == "ollama"
         if use_ollama:
             api_key = os.getenv("OLLAMA_API_KEY")
             base_url = os.getenv("OLLAMA_API_BASE_URL")

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import asyncio
 from dotenv import load_dotenv
 from pyrogram import Client, filters
 from pyrogram.types import Message
+from pyrogram.enums import ChatAction
 from ai_client import AIClient
 from bot_utils import process_waiting_messages
 
@@ -46,6 +47,7 @@ async def handle_message(client: Client, message: Message):
             waiting_users[user_id].append(message)
             return
         waiting_users[user_id] = [message]
+        await client.send_chat_action(user_id, ChatAction.TYPING)
         asyncio.create_task(
             process_waiting_messages(client, user_id, waiting_users, waiting_lock, ai_client)
         )

--- a/bot_utils.py
+++ b/bot_utils.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 from pyrogram import Client
 from pyrogram.types import Message
+from pyrogram.enums import ChatAction
 
 SYSTEM_PROMPTS_DIR = "prompts"
 with open("system_prompt.txt", "r", encoding="utf-8") as f:
@@ -145,4 +146,6 @@ async def process_waiting_messages(client: Client, user_id: int, waiting_users, 
         print(f"⛔ Error for chat {user_id}: {e}")
     except Exception as e:
         print(f"⛔ Unexpected error for chat {user_id}: {e}")
+    finally:
+        await client.send_chat_action(user_id, ChatAction.CANCEL)
 

--- a/prompt_generator.py
+++ b/prompt_generator.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import asyncio
+from dotenv import load_dotenv
+from pyrogram import Client
+from ai_client import AIClient
+
+
+async def main():
+    if len(sys.argv) != 3:
+        print("Usage: python prompt_generator.py <user_id> <openai|ollama>")
+        return
+
+    user_id = int(sys.argv[1])
+    api_type = sys.argv[2].lower()
+    if api_type not in {"openai", "ollama"}:
+        print("API type must be 'openai' or 'ollama'")
+        return
+
+    load_dotenv(".env")
+
+    client = Client(
+        name=os.getenv("APP_NAME"),
+        api_id=int(os.getenv("API_ID")),
+        api_hash=os.getenv("API_HASH"),
+    )
+
+    history = []
+    async with client:
+        async for m in client.get_chat_history(user_id, limit=200):
+            if m.text or m.caption:
+                history.append(m)
+
+    history.reverse()
+    lines = []
+    for m in history:
+        role = "Victor" if m.outgoing else "User"
+        text = m.text or m.caption or ""
+        lines.append(f"{role}: {text}")
+    conversation = "\n".join(lines)
+
+    prompt_text = (
+        "Analyze the following message history and write a system prompt for "
+        "impersonating real man Victor conversation with this user:\n\n" + conversation
+    )
+
+    messages = [{"role": "user", "content": prompt_text}]
+    ai = AIClient(api_type=api_type)
+    result = ai.complete(messages)
+
+    os.makedirs("prompts", exist_ok=True)
+    out_path = os.path.join("prompts", f"{user_id}.txt")
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(result.strip())
+    print(f"Prompt saved to {out_path}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- show typing status when a message is queued and cancel after replying
- allow AIClient to select API explicitly
- implement `prompt_generator.py` to create a tailored system prompt

## Testing
- `python -m py_compile app.py bot_utils.py ai_client.py prompt_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_686bfd1f37848328bb9ab2df4f08a111