### PR TITLE
Add username to prompts

### DIFF
--- a/bot_utils.py
+++ b/bot_utils.py
@@ -10,13 +10,13 @@ SYSTEM_PROMPTS_DIR = "prompts"
 with open("system_prompt.txt", "r", encoding="utf-8") as f:
     GENERAL_SYSTEM_PROMPT = f.read().strip()
 
-def get_system_prompt(user_id: int) -> str:
+def get_system_prompt(user_id: int, user_name: str) -> str:
     path = os.path.join(SYSTEM_PROMPTS_DIR, f"{user_id}.txt")
     if os.path.exists(path):
         print(f"ℹ️ Using custom system prompt for user {user_id}")
         with open(path, "r", encoding="utf-8") as f:
             return f.read().strip()
-    return GENERAL_SYSTEM_PROMPT
+    return GENERAL_SYSTEM_PROMPT + f"\nThe other person's name is {user_name}."
 
 async def message_to_content(client: Client, msg: Message):
     parts = []
@@ -115,7 +115,8 @@ async def process_waiting_messages(client: Client, user_id: int, waiting_users, 
         msgs = waiting_users.pop(user_id, [])
     if not msgs:
         return
-    system_prompt = get_system_prompt(user_id)
+    user_name = msgs[-1].from_user.first_name or msgs[-1].from_user.username or str(user_id)
+    system_prompt = get_system_prompt(user_id, user_name)
     print(f"🤖 Processing {len(msgs)} messages from {user_id}")
     try:
         history = []

--- a/prompt_generator.py
+++ b/prompt_generator.py
@@ -27,6 +27,8 @@ async def main():
 
     history = []
     async with client:
+        user = await client.get_users(user_id)
+        user_name = user.first_name or user.username or str(user_id)
         async for m in client.get_chat_history(user_id, limit=200):
             if m.text or m.caption:
                 history.append(m)
@@ -34,14 +36,14 @@ async def main():
     history.reverse()
     lines = []
     for m in history:
-        role = os.getenv("MY_USER_NAME") if m.outgoing else "User"
+        role = os.getenv("MY_USER_NAME") if m.outgoing else user_name
         text = m.text or m.caption or ""
         lines.append(f"{role}: {text}")
     conversation = "\n".join(lines)
 
     prompt_text = (
         "Analyze the following message history and write a system prompt in Ukrainian language for LLM "
-        f"impersonating real man {os.getenv("MY_USER_NAME")} conversation with this user:\n\n" + conversation
+        f"impersonating real man {os.getenv('MY_USER_NAME')} conversation with {user_name}:\n\n" + conversation
     )
 
     print(f"ℹ️ Sending request to AI: {prompt_text}");


### PR DESCRIPTION
## Summary
- inject user's first name into history lines for prompt generation
- include opponent's name when generating system prompt if no specific prompt exists
- update processing to pass user name

## Testing
- `python -m py_compile app.py bot_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_686c0385dc388328842d529bd5a266f9