### PR TITLE
Add model loading and timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ VictorGram is a small Telegram bot that uses [Pyrogram](https://docs.pyrogram.or
    - `APP_NAME` – Pyrogram session name
    - `API_ID` and `API_HASH` – values from [my.telegram.org](https://my.telegram.org)
    - `OPENAI_API_KEY` – key for OpenAI or configure OLLAMA variables
+   - `MODEL_UNLOAD_TIMEOUT` – seconds to keep models loaded (default 1800)
 3. Put a system prompt for that instance into `system/<instance>.txt` (an example file `system/example.txt` is provided).
 4. Run the bot (for example to start the `example` instance):
   ```bash


### PR DESCRIPTION
## Summary
- preload whisper and verify Ollama model on startup
- unload whisper model after inactivity timeout
- document `MODEL_UNLOAD_TIMEOUT`

`python -m py_compile app.py bot_utils.py ui.py` ran without errors.

## Testing
- `python -m py_compile app.py bot_utils.py ui.py`

------
https://chatgpt.com/codex/tasks/task_e_686e6eb89a7c83289011613312658129