### PR TITLE
Improve logging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ VictorGram is a small Telegram bot that uses [Pyrogram](https://docs.pyrogram.or
 
 ## Setup
 
-1. Install the requirements:
+1. Install the requirements and ensure `ffmpeg` is available (required for `openai-whisper`):
    ```bash
    pip install -r requirements.txt
    ```

--- a/app.py
+++ b/app.py
@@ -18,27 +18,39 @@ if hasattr(sys.stdout, "reconfigure"):
 
 
 def setup_logging(name: str):
-    logger = logging.getLogger()
-    if logger.handlers:
+    root_logger = logging.getLogger()
+    if root_logger.handlers:
         return
-    logger.setLevel(logging.INFO)
+
+    root_logger.setLevel(logging.INFO)
+
     fmt = logging.Formatter("%(asctime)s %(message)s", datefmt="%H:%M")
-    stream = logging.StreamHandler(sys.stdout)
-    stream.setFormatter(fmt)
-    logger.addHandler(stream)
+
+    error_handler = logging.StreamHandler(sys.stderr)
+    error_handler.setLevel(logging.ERROR)
+    error_handler.setFormatter(fmt)
+    root_logger.addHandler(error_handler)
+
     if name:
         os.makedirs("logs", exist_ok=True)
         file_handler = logging.FileHandler(
             os.path.join("logs", f"{name}.log"), encoding="utf-8"
         )
         file_handler.setFormatter(fmt)
-        logger.addHandler(file_handler)
+        file_handler.setLevel(logging.INFO)
+        root_logger.addHandler(file_handler)
+
+    print_logger = logging.getLogger("print")
+    print_logger.setLevel(logging.INFO)
+    info_handler = logging.StreamHandler(sys.stdout)
+    info_handler.setFormatter(fmt)
+    print_logger.addHandler(info_handler)
 
 
 setup_logging(instance)
 
 def log_print(*args, sep=" ", end="\n", **kwargs):
-    logging.getLogger().info(sep.join(str(a) for a in args))
+    logging.getLogger("print").info(sep.join(str(a) for a in args))
 
 
 print = log_print


### PR DESCRIPTION
## Summary
- restrict console output to error logs only
- keep print output using a dedicated logger
- mention ffmpeg as a prerequisite for openai-whisper in README

## Testing
- `python -m py_compile app.py bot_utils.py ui.py`

------
https://chatgpt.com/codex/tasks/task_e_686e82dea29c8328b0b331b76d712149