### PR TITLE
Add PDF and DOCX document handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ VictorGram is a Telegram bot powered by [Pyrogram](https://docs.pyrogram.org/). 
 ## Features
 
 * Works only in private chats.
-* Supports text, images and voice messages. Audio is transcribed with Whisper and text files are also read.
+* Supports text, images, PDF and DOCX documents and voice messages. Audio is transcribed with Whisper and text files are also read. PDF files are converted to images and DOCX files are converted to text.
 * Adds current date, time and optional weather information to the system prompt.
 * Messages from the same user are queued before being sent to the LLM.
 * System prompts can be customised per user by placing a file in `prompts/<instance>/<user_id>.txt`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ openai>=1.0.0
 streamlit
 openai-whisper
 requests
+pdf2image
+python-docx


### PR DESCRIPTION
## Summary
- convert PDF files to images and extract text from DOCX
- cache parsed documents
- keep only last document or image when building context
- mention new features in README
- add required libraries

## Testing
- `python -m py_compile app.py bot_utils.py ui.py`

------
https://chatgpt.com/codex/tasks/task_e_68701ca737f88328aa96c51049195792