### PR TITLE
Add topic-aware replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ VictorGram is a Telegram bot powered by [Pyrogram](https://docs.pyrogram.org/). 
 * Messages from the same user are queued before being sent to the LLM.
 * System prompts can be customised per user by placing a file in `prompts/<instance>/<user_id>.txt`.
 * System prompts can be customised per group by placing a file in `prompts/<instance>/groups/<group_id>.txt`.
+* Replies in the same group topic or channel where the bot was triggered.
 * Can use OpenAI or local Ollama models and unloads models after a period of inactivity.
 * A Streamlit UI (`ui.py`) allows starting and stopping instances.
 * `prompt_generator.py` can create personal system prompts from chat history and update user and group names.

--- a/app.py
+++ b/app.py
@@ -138,6 +138,7 @@ async def handle_message(client: Client, message: Message):
 async def handle_group_message(client: Client, message: Message):
     chat_id = message.chat.id
     chat_name = message.chat.title
+    thread_id = message.message_thread_id or 0
     if chat_id not in included_groups:
         print(f"Skipping not included group: {chat_id}: {chat_name}")
         return
@@ -163,12 +164,15 @@ async def handle_group_message(client: Client, message: Message):
     )
 
     delay = 0 if mentioned else int(os.getenv("GROUP_MESSAGE_WAIT_TIME", 60))
+    key = (chat_id, thread_id)
     async with waiting_lock:
-        if chat_id in waiting_groups:
-            waiting_groups[chat_id].append(message)
+        if key in waiting_groups:
+            waiting_groups[key].append(message)
             if mentioned:
-                group_reply_targets[chat_id] = message
-                await client.send_chat_action(chat_id, ChatAction.TYPING)
+                group_reply_targets[key] = message
+                await client.send_chat_action(
+                    chat_id, ChatAction.TYPING, message_thread_id=thread_id
+                )
                 asyncio.create_task(
                     process_waiting_messages(
                         client,
@@ -178,12 +182,16 @@ async def handle_group_message(client: Client, message: Message):
                         ai_client,
                         delay=0,
                         reply_targets=group_reply_targets,
+                        key=key,
+                        thread_id=thread_id,
                     )
                 )
             return
-        waiting_groups[chat_id] = [message]
-        group_reply_targets[chat_id] = message if mentioned else None
-        await client.send_chat_action(chat_id, ChatAction.TYPING)
+        waiting_groups[key] = [message]
+        group_reply_targets[key] = message if mentioned else None
+        await client.send_chat_action(
+            chat_id, ChatAction.TYPING, message_thread_id=thread_id
+        )
         asyncio.create_task(
             process_waiting_messages(
                 client,
@@ -193,6 +201,8 @@ async def handle_group_message(client: Client, message: Message):
                 ai_client,
                 delay=delay,
                 reply_targets=group_reply_targets,
+                key=key,
+                thread_id=thread_id,
             )
         )
 


### PR DESCRIPTION
## Summary
- support replying within the same group topic
- send typing notifications and messages with thread awareness
- document topic support in README

## Testing
- `python -m py_compile app.py bot_utils.py ui.py`

------
https://chatgpt.com/codex/tasks/task_e_6871153af5c883288e43ade4a266cef5