### PR TITLE
Use raw API for group topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ VictorGram is a Telegram bot powered by [Pyrogram](https://docs.pyrogram.org/). 
 * Messages from the same user are queued before being sent to the LLM.
 * System prompts can be customised per user by placing a file in `prompts/<instance>/<user_id>.txt`.
 * System prompts can be customised per group by placing a file in `prompts/<instance>/groups/<group_id>.txt`.
-* Replies in the same group topic or channel where the bot was triggered.
+* Replies in the same group topic or channel where the bot was triggered using Pyrogram's raw API.
 * Can use OpenAI or local Ollama models and unloads models after a period of inactivity.
 * A Streamlit UI (`ui.py`) allows starting and stopping instances.
 * `prompt_generator.py` can create personal system prompts from chat history and update user and group names.

--- a/app.py
+++ b/app.py
@@ -170,9 +170,7 @@ async def handle_group_message(client: Client, message: Message):
             waiting_groups[key].append(message)
             if mentioned:
                 group_reply_targets[key] = message
-                await client.send_chat_action(
-                    chat_id, ChatAction.TYPING, message_thread_id=thread_id
-                )
+                await client.send_chat_action(chat_id, ChatAction.TYPING)
                 asyncio.create_task(
                     process_waiting_messages(
                         client,
@@ -189,9 +187,7 @@ async def handle_group_message(client: Client, message: Message):
             return
         waiting_groups[key] = [message]
         group_reply_targets[key] = message if mentioned else None
-        await client.send_chat_action(
-            chat_id, ChatAction.TYPING, message_thread_id=thread_id
-        )
+        await client.send_chat_action(chat_id, ChatAction.TYPING)
         asyncio.create_task(
             process_waiting_messages(
                 client,


### PR DESCRIPTION
## Summary
- update README to mention raw API usage for group topics
- add `send_topic_message` helper using `pyrogram.raw` and adapt waiting loop
- drop unsupported `message_thread_id` parameters

## Testing
- `python -m py_compile app.py bot_utils.py ui.py`

------
https://chatgpt.com/codex/tasks/task_e_687118628ee48328ae3d6f3b91aba54e