### PR TITLE
Support telegram group topics

### DIFF
--- a/app.py
+++ b/app.py
@@ -154,8 +154,10 @@ async def handle_group_message(client: Client, message: Message):
     bot_username = client.me.username if client.me else ""
     mentioned = False
     if bot_username and f"@{bot_username.lower()}" in text.lower():
+        print(f"Message mentions bot in group: {chat_id}")
         mentioned = True
-    if message.reply_to_message and message.reply_to_message.from_user and message.reply_to_message.from_user.id == client.me.id:
+    if message.mentioned:
+        print(f"Message mentions by mentioned in group: {chat_id}")
         mentioned = True
 
     print(
@@ -169,6 +171,7 @@ async def handle_group_message(client: Client, message: Message):
     chat_key = (chat_id, topic_id)
 
     delay = 0 if mentioned else int(os.getenv("GROUP_MESSAGE_WAIT_TIME", 60))
+    print(f"🤖 Delaying group message in {chat_id} by {delay}s")
     async with waiting_lock:
         if chat_key in waiting_groups:
             waiting_groups[chat_key].append(message)

--- a/bot_utils.py
+++ b/bot_utils.py
@@ -5,6 +5,7 @@ import base64
 import random
 from io import BytesIO
 from pyrogram import Client
+from pyrogram import raw
 from pyrogram.types import Message
 from ai_client import AIClient
 from pyrogram.enums import ChatAction
@@ -208,24 +209,44 @@ async def send_typing_loop(client: Client, chat_id: int, stop_event: asyncio.Eve
             print(f"⛔ Typing notification error for {chat_id}: {e}")
         await asyncio.sleep(random.uniform(2, 3))
 
+async def send_message_in_topic(client: Client, chat_id: int, text: str, topic_id: int | None):
+    if not topic_id:
+        await client.send_message(chat_id, text)
+        return
+
+    try:
+        await client.invoke(
+            raw.functions.messages.SendMessage(
+                peer=await client.resolve_peer(chat_id),
+                message=text,
+                random_id=client.rnd_id(),
+                top_msg_id=topic_id,
+            )
+        )
+    except Exception as e:
+        print(f"⛔ Failed to send message in topic {chat_id}:{topic_id}: {e}")
+
+
 async def process_waiting_messages(
     client: Client,
-    chat_id: int,
+    chat_key,
     waiting_dict,
     waiting_lock,
     ai_client,
     delay: int | None = None,
     reply_targets: dict | None = None,
 ):
-    print(f"🤖 Processing waiting messages for {chat_id}")
+    chat_id = chat_key[0] if isinstance(chat_key, tuple) else chat_key
+    topic_id = chat_key[1] if isinstance(chat_key, tuple) else None
+    print(f"🤖 Processing waiting messages for {chat_id}:{topic_id}")
     if delay is None:
         delay = int(os.getenv("NEXT_MESSAGE_WAIT_TIME", 10))
     await asyncio.sleep(delay)
     async with waiting_lock:
-        msgs = waiting_dict.pop(chat_id, [])
+        msgs = waiting_dict.pop(chat_key, [])
         reply_to = None
         if reply_targets is not None:
-            reply_to = reply_targets.pop(chat_id, None)
+            reply_to = reply_targets.pop(chat_key, None)
     if not msgs:
         return
     if chat_id < 0:
@@ -237,12 +258,16 @@ async def process_waiting_messages(
             or str(chat_id)
         )
     system_prompt = enhance_system_prompt(get_system_prompt(chat_id, user_name))
-    print(f"🤖 Processing {len(msgs)} messages from {chat_id}")
+    print(f"🤖 Processing {len(msgs)} messages from {chat_id}:{topic_id}")
     try:
         history = []
         limit = int(os.getenv("HISTORY_LIMIT")) + len(msgs)
-        async for m in client.get_chat_history(chat_id, limit=limit):
-            history.append(m)
+        if topic_id:
+            async for m in client.get_discussion_replies(chat_id, topic_id, limit=limit):
+                history.append(m)
+        else:
+            async for m in client.get_chat_history(chat_id, limit=limit):
+                history.append(m)
 
         for m in reversed(msgs):
             if history and history[0].id == m.id:
@@ -262,7 +287,7 @@ async def process_waiting_messages(
         if reply_to is not None:
             await reply_to.reply_text(reply)
         else:
-            await client.send_message(chat_id, reply)
+            await send_message_in_topic(client, chat_id, reply, topic_id)
     except ValueError as e:
         print(f"⛔ Error for chat {chat_id}: {e}")
     except KeyError as e:


### PR DESCRIPTION
## Summary
- add raw helper to send messages within a forum topic
- allow queue handling keyed by chat and topic
- restrict history to same topic via `get_discussion_replies`

## Testing
- `python -m py_compile app.py bot_utils.py ui.py`

------
https://chatgpt.com/codex/tasks/task_e_687129fd7f1083289f6a082ea7f2ea32